### PR TITLE
Corrected inaccurate source-code comments and trimmed redundant ones.

### DIFF
--- a/benchmarks/DiscoveryBenchmark.php
+++ b/benchmarks/DiscoveryBenchmark.php
@@ -16,7 +16,7 @@ class DiscoveryBenchmark {
   }
 
   /**
-   * Data provider for the `benchAddProvider` benchmark.
+   * Benchmark registering custom providers.
    *
    * @param array<string,int> $params
    *   An array of parameters.
@@ -80,7 +80,7 @@ class DiscoveryBenchmark {
   }
 
   /**
-   * Data provider for the `benchAddContext` benchmark.
+   * Benchmark registering custom contexts.
    *
    * @param array<string,int> $params
    *   An array of parameters.

--- a/benchmarks/InitBenchmark.php
+++ b/benchmarks/InitBenchmark.php
@@ -16,7 +16,7 @@ class InitBenchmark {
   }
 
   /**
-   * Data provider for the `provideInitRepeated` benchmark.
+   * Benchmark repeated type checks after init.
    *
    * @param array<string,int|bool> $params
    *   An array of parameters.

--- a/src/Contexts/AbstractContext.php
+++ b/src/Contexts/AbstractContext.php
@@ -14,12 +14,12 @@ namespace DrevOps\EnvironmentDetector\Contexts;
 abstract class AbstractContext implements ContextInterface {
 
   /**
-   * Context ID. Provers should override this constant.
+   * Context ID. Contexts should override this constant.
    */
   public const ID = 'undefined';
 
   /**
-   * Context label. Provers should override this constant.
+   * Context label. Contexts should override this constant.
    */
   public const LABEL = 'undefined';
 

--- a/src/Contexts/ContextInterface.php
+++ b/src/Contexts/ContextInterface.php
@@ -8,7 +8,7 @@ namespace DrevOps\EnvironmentDetector\Contexts;
  * Context interface.
  *
  * Context is a framework/CMS that runs in the environment. Once the context is
- * detected, it can be used to conextualize (apply changes) to the running
+ * detected, it can be used to contextualize (apply changes) to the running
  * environment. This can include setting environment variables, changing
  * configuration files, etc.
  *

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -51,15 +51,15 @@ use DrevOps\EnvironmentDetector\Providers\ProviderInterface;
  * returns NULL. In this case, the fallback environment type is used.
  * The fallback environment type can be overridden using the ::setFallback()
  * method.
- * The default fallback environment type is Environment::DEV - this is to make
- * sure that, in case of misconfiguration, the application does not apply local
- * settings in production or production settings in local - 'dev' type is
- * the safest default.
+ * The default fallback environment type is Environment::DEVELOPMENT - this is
+ * to make sure that, in case of misconfiguration, the application does not
+ * apply local settings in production or production settings in local -
+ * 'development' type is the safest default.
  *
  * The discovered type is statically cached to be performant. The cache can be
- * reset using the ::reset() method, which will reset the detected type and the
- * active provider, but will preserver the registered providers.
- * Call ::reset(TRUE) to reset all registered providers as well.
+ * reset using the ::reset() method, which resets the active provider and
+ * context and the registered providers and contexts. Call ::reset(TRUE) to
+ * also reset the fallback type and the override callback.
  *
  * ** Contexts **
  *
@@ -120,7 +120,7 @@ use DrevOps\EnvironmentDetector\Providers\ProviderInterface;
  * Environment::init(
  *   contextualize: TRUE,                             // Whether to apply the context automatically when the environment type is requested.
  *   fallback: Environment::DEVELOPMENT               // The fallback environment type.
- *   override_callback: function($provider, $type) {  // The override callback to change the environment type.
+ *   override: function($provider, $type) {           // The override callback to change the environment type.
  *     // Custom logic to override the detected environment type.
  *    return $type;
  *   }
@@ -299,7 +299,7 @@ class Environment {
    * Environment::init(
    *   contextualize: TRUE,                             // Whether to apply the context automatically when the environment type is requested.
    *   fallback: Environment::DEVELOPMENT               // The fallback environment type.
-   *   override_callback: function($provider, $type) {  // The override callback to change the environment type.
+   *   override: function($provider, $type) {           // The override callback to change the environment type.
    *     // Custom logic to override the detected environment type.
    *    return $type;
    *   },
@@ -416,8 +416,6 @@ class Environment {
       $active = NULL;
 
       // Ensure at most one active provider exists.
-      // Stop checking as soon as more than one is detected to avoid unnecessary
-      // evaluations.
       $providers = static::collectProviders();
       foreach ($providers as $provider) {
         if ($provider->active()) {
@@ -509,8 +507,6 @@ class Environment {
       $active = NULL;
 
       // Ensure at most one active context exists.
-      // Stop checking as soon as more than one is detected to avoid unnecessary
-      // evaluations.
       $contexts = static::collectContexts();
       foreach ($contexts as $context) {
         if ($context->active()) {

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -26,7 +26,7 @@ abstract class AbstractProvider implements ProviderInterface {
   public const LABEL = 'undefined';
 
   /**
-   * Environment variables prefix. Providers should override this constant.
+   * Get the environment variable prefixes used by the provider.
    *
    * @return array<string>
    *   The list of environment variable prefixes used by the provider.

--- a/src/Providers/Docker.php
+++ b/src/Providers/Docker.php
@@ -9,7 +9,7 @@ use DrevOps\EnvironmentDetector\Environment;
 /**
  * Docker (vanilla) provider.
  *
- * Detects the DDEV environment type.
+ * Detects the Docker environment type.
  *
  * @package DrevOps\EnvironmentDetector\Providers
  */

--- a/src/Providers/Lagoon.php
+++ b/src/Providers/Lagoon.php
@@ -18,7 +18,6 @@ class Lagoon extends AbstractProvider {
   /**
    * {@inheritdoc}
    */
-
   public const ID = 'lagoon';
 
   /**
@@ -46,7 +45,6 @@ class Lagoon extends AbstractProvider {
   public function type(): ?string {
     $type = NULL;
 
-    // Environment is marked as 'production'.
     if (getenv('LAGOON_ENVIRONMENT_TYPE') == 'production') {
       $type = Environment::PRODUCTION;
     }
@@ -81,8 +79,6 @@ class Lagoon extends AbstractProvider {
 
     // Lagoon reverse proxy settings.
     $settings['reverse_proxy'] = TRUE;
-
-    // Reverse proxy settings.
     $settings['reverse_proxy_header'] = 'HTTP_TRUE_CLIENT_IP';
 
     // Cache prefix.


### PR DESCRIPTION
## Summary

This is a comment-only cleanup across 8 files with zero behavior change. It corrects docblocks and inline comments that contradicted the actual code, fixes two typos, and removes comments that were either redundant or actively misleading about what the code does.

## Changes

### Comments that contradicted the code

- **`src/Providers/Docker.php`**: Class docblock said "Detects the DDEV environment type" - corrected to "Detects the Docker environment type."
- **`src/Contexts/AbstractContext.php`**: `ID` and `LABEL` constants were documented as "Provers should override this constant" (wrong entity, typo) - corrected to "Contexts should override this constant."
- **`src/Providers/AbstractProvider.php`**: `envPrefixes()` docblock described it as "Environment variables prefix. Providers should override this constant" - it is an abstract method, not a constant; rewritten to "Get the environment variable prefixes used by the provider."
- **`src/Environment.php`** (class docblock): Referenced a non-existent `Environment::DEV` constant - corrected to `Environment::DEVELOPMENT`.
- **`src/Environment.php`** (class docblock `reset()` description): The description claimed `::reset()` "will preserve the registered providers" and that `::reset(TRUE)` resets all providers - this was the inverse of reality. Corrected: `::reset()` resets the active provider, context, and all registered providers/contexts; `::reset(TRUE)` additionally resets the fallback type and override callback.
- **`src/Environment.php`** (two `@code` examples): Both passed the parameter as `override_callback:` (a named-argument syntax) but the actual parameter name is `$override` - corrected to `override:` in both occurrences.
- **`src/Contexts/ContextInterface.php`**: Fixed typo "conextualize" -> "contextualize".

### Redundant or misleading comments removed

- **`src/Environment.php`** (`getActiveProvider()` and `getActiveContext()`): Removed "Stop checking as soon as more than one is detected to avoid unnecessary evaluations." Both methods actually throw an exception when a second active provider/context is found - the comment implied an early-return optimization rather than an error condition.
- **`src/Providers/Lagoon.php`**: Removed stray blank line between the `{@inheritdoc}` docblock and `public const ID` (blank line orphaned the docblock from its declaration).
- **`src/Providers/Lagoon.php`** (`type()`): Removed inline comment "Environment is marked as 'production'." that merely restated the `if` condition immediately below it.
- **`src/Providers/Lagoon.php`** (`contextualizeDrupal()`): Removed duplicate "Reverse proxy settings." comment that appeared two lines after "Lagoon reverse proxy settings." and covered the same setting.
- **`benchmarks/DiscoveryBenchmark.php`**: Two benchmark method docblocks claimed to be "Data provider for the `benchAddProvider`/`benchAddContext` benchmark" - neither is a data provider and those method names do not exist; corrected to describe what each method actually benchmarks.
- **`benchmarks/InitBenchmark.php`**: Benchmark method docblock claimed to be "Data provider for the `provideInitRepeated` benchmark" - corrected to describe the actual benchmark behavior.

## Before / After

```
// BEFORE - Docker.php
/**
 * Docker (vanilla) provider.
 *
 * Detects the DDEV environment type.        <-- wrong provider name
 */

// AFTER - Docker.php
/**
 * Docker (vanilla) provider.
 *
 * Detects the Docker environment type.
 */

---

// BEFORE - Environment.php class docblock (reset description)
 * reset using the ::reset() method, which will reset the detected type and the
 * active provider, but will preserver the registered providers.
 * Call ::reset(TRUE) to reset all registered providers as well.
                                              ^-- inverted: reset() already clears providers;
                                                  reset(TRUE) clears fallback + override

// AFTER - Environment.php class docblock
 * reset using the ::reset() method, which resets the active provider and
 * context and the registered providers and contexts. Call ::reset(TRUE) to
 * also reset the fallback type and the override callback.

---

// BEFORE - Environment.php @code example (wrong named-argument)
 *   override_callback: function($provider, $type) {

// AFTER
 *   override: function($provider, $type) {
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling errors and improved clarity in internal documentation and comments across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
