### PR TITLE
Clarified the README and unified platform and stack terminology.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 
 ---
 
-Answers one question, with no configuration: **what kind of environment is this code running in?** It maps the host you are on to a single environment type - `local`, `ci`, `development`, `preview`, `stage`, or `production` - across common hosting providers, CI services, and local stacks.
+Answers one question, with no configuration: **what kind of environment is this code running in?** It detects a single environment type - `local`, `ci`, `development`, `preview`, `stage`, or `production` - from the hosting platform or CI platform the code runs on, and also recognises the local stack (native host or container) beneath it.
 
 - Zero configuration: a single call detects and caches the type.
-- Recognises hosting platforms (Acquia, Lagoon, Pantheon, Platform.sh, Skpr, Tugboat) and CI services (GitHub Actions, GitLab CI, CircleCI).
-- Recognises local stacks (Native, Container, DDEV, Lando).
+- Recognises hosting platforms (Acquia, Lagoon, Pantheon, Platform.sh, Skpr, Tugboat) and CI platforms (GitHub Actions, GitLab CI, CircleCI).
+- Recognises the stack it runs on (native host, Container, DDEV, Lando).
 - Applies framework-specific settings through contexts (Drupal).
-- Extendable with custom platforms, stacks, and contexts, with a safe fallback type.
+- Extensible with custom platforms, stacks, and contexts, with a safe fallback type.
 
 ## Installation
 
@@ -58,7 +58,7 @@ If `ENVIRONMENT_TYPE` is already set, that value wins - handy for forcing a type
 
 ## How it works
 
-A run is a set of nested rings, from an outer context down to the application:
+A run is a set of nested rings, from the outermost ring inward to the application:
 
 ```text
 ┌─ PLATFORM ── hosting (tiered) · CI (flat) · none ⇒ local ───────────────┐
@@ -72,14 +72,14 @@ A run is a set of nested rings, from an outer context down to the application:
 ```
 
 - **Platform** - the outermost ring, and the *only* one that decides the type. A hosting platform maps to `production`/`stage`/`development`/`preview`; a CI platform maps to `ci`; with no platform at all the type is `local` (or `ci` when a generic `CI` signal is present).
-- **Stack** - the substrate the run sits in (`native`, `container`, `ddev`, `lando`). A stack nests inside a platform, never decides the type, and only contributes settings. `ddev` and `lando` are specific containers, `container` is the generic container fallback, and `native` is the bare-metal host used when nothing containerised matches.
+- **Stack** - the substrate the run sits in (`native`, `container`, `ddev`, `lando`). A stack nests inside a platform, never decides the type, and only contributes settings. `ddev` and `lando` are specific containers, `container` is the generic container fallback, and `native` is the native host (bare metal), the fallback when nothing else matches.
 - **Context** - the application/framework (e.g. Drupal) that detected settings are applied to.
 - **Runtime** (PHP) is shown only to complete the picture; it is not detected.
 
 Two rules follow:
 
 1. **At most one platform is active.** Two active platforms (say Acquia *and* Lagoon) is a genuine misconfiguration and throws.
-2. **Exactly one stack is always active - the most specific container that matches, or the native host on bare metal.** A container inside Acquia, or inside CI, is just an inner ring - it never collides with the platform. The most specific container wins (DDEV over the generic container, say); `container` is the generic fallback, and `native` is the bare-metal host when nothing containerised matches.
+2. **Exactly one stack is always active - the most specific stack that matches, or the native host as the fallback.** A container inside Acquia or inside CI is just an inner ring; it never collides with the platform. The most specific match wins - DDEV over the generic `container`, say - and the native host is the last-resort fallback when nothing else matches.
 
 When a context is active, it applies its generic settings first, then the active platform and the active stack apply their own on top. This happens even when the type was pre-set via `ENVIRONMENT_TYPE`.
 
@@ -90,14 +90,14 @@ When a context is active, it applies its generic settings first, then the active
 ```php
 Environment::init(
   contextualize: TRUE,                 // Apply context settings automatically (default).
-  fallback: Environment::DEVELOPMENT,  // Type used when a platform cannot name its tier.
+  fallback: Environment::DEVELOPMENT,  // Type used when a platform cannot resolve its tier.
   platforms: [new MyHostingPlatform()],
   stacks: [new MyStack()],
   contexts: [new MyContext()],
 );
 ```
 
-The fallback (`development` by default) applies only when a platform is active but cannot resolve a tier - it is never used to silently downgrade a known environment. It guards against applying local settings in production, or production settings locally.
+The fallback (`development` by default) applies only when a platform is active but cannot resolve its tier - it is never used to silently downgrade a known environment. It guards against applying local settings in production, or production settings locally.
 
 ## Platforms
 
@@ -158,7 +158,7 @@ Environment::init(platforms: [new CustomHosting()]);
 
 ## Stacks
 
-A stack is the substrate the run sits in. Stacks never decide the type. Exactly one stack is always active - the most specific registered stack that matches, or the native host on bare metal. `Container` is the generic container fallback, `Ddev` and `Lando` are specific containers that match only when they are also a container, and `Native` is the bare-metal host selected when nothing containerised matches. Built-ins:
+A stack is the substrate the run sits in. Stacks never decide the type. Exactly one stack is always active - the most specific stack that matches, or the native host as the last-resort fallback. `Container` is the generic container fallback, `Ddev` and `Lando` are specific containers that match only when running inside a container, and `Native` is the native host, used when nothing else matches. Built-ins:
 
 - [Container](src/Stacks/Container.php)
 - [DDEV](src/Stacks/Ddev.php)


### PR DESCRIPTION
## Summary

A readability and terminology-consistency pass over the README. Establishes one unified vocabulary: a Platform (hosting or CI) is the only ring that decides the environment type; a Stack is the substrate (native host or container) and never decides the type; a Context is where detected settings land. No behaviour or code changes.

## Changes

- Unified platform language: "hosting providers" and "CI services" are now "hosting platforms" and "CI platforms" throughout.
- Unified stack language: the substrate is consistently described as the "native host" or a "container"; the bare-metal fallback is always the "native host" / "last-resort fallback" rather than "bare-metal host" or "native".
- Realigned rule 2 in "How it works" with the Stacks section ("most specific stack that matches, or the native host as the fallback").
- Fixed "from an outer context" → "from the outermost ring inward" (the old phrasing reused the defined term "context").
- Fixed "Extendable" → "Extensible".
- Standardised "resolve its tier" in place of "name its tier" / "resolve a tier".

## Screenshots

N/A

## Before / After

```
BEFORE                                    AFTER
──────────────────────────────────────    ──────────────────────────────────────
hosting providers                    →    hosting platforms
CI services                          →    CI platforms
bare-metal host / "native"           →    native host (bare metal), last-resort fallback
most specific container that matches →    most specific stack that matches
  or the native host on bare metal        or the native host as the fallback
cannot name its tier                 →    cannot resolve its tier
resolve a tier                       →    resolve its tier
from an outer context down           →    from the outermost ring inward
Extendable                           →    Extensible
```
