### PR TITLE
[#79] Mapped Acquia 'stage' and on-demand environments to stage and preview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If `ENVIRONMENT_TYPE` is already set, that value wins - handy for forcing a type
 
 ## Environment types
 
-Detection always resolves to exactly one of these types:
+The built-in detectors resolve to one of these types (a custom platform can return its own, read via `Environment::is('custom-type')`):
 
 | Type | What it is | Lifespan |
 |------|-----------|----------|

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ if (getenv('ENVIRONMENT_TYPE') === Environment::PRODUCTION) {
 
 If `ENVIRONMENT_TYPE` is already set, that value wins - handy for forcing a type while debugging.
 
+## Environment types
+
+Detection always resolves to exactly one of these types:
+
+| Type | What it is | Lifespan |
+|------|-----------|----------|
+| `local` | Your own machine or local stack (native host, DDEV, Lando, Docker); no hosting platform is active. | Persistent (developer-owned) |
+| `ci` | An automated CI runner (GitHub Actions, GitLab CI, CircleCI). | Ephemeral, per job |
+| `development` | A shared, long-lived hosting environment for ongoing integration work. Also the safe [fallback](#configuration). | Persistent |
+| `preview` | A short-lived, throwaway per-branch or per-PR environment with its own fully-built site on its own standalone URL. | Ephemeral |
+| `stage` | A persistent pre-production environment that mirrors production; used for UAT, QA, and release sign-off. | Persistent |
+| `production` | The live environment serving real users. | Persistent |
+
+`preview` is the only ephemeral, per-change tier with its own URL - which is what sets it apart from `development` (shared and long-lived) and `stage` (a persistent pre-production mirror).
+
 ## How it works
 
 A run is a set of nested rings, from the outermost ring inward to the application:
@@ -112,6 +127,21 @@ A platform is the outermost ring and the only one that decides the type. Built-i
 - [Platform.sh](src/Platforms/PlatformSh.php)
 - [Skpr](src/Platforms/Skpr.php)
 - [Tugboat](src/Platforms/Tugboat.php)
+
+### How platforms map to types
+
+Each hosting platform reads its own signal (usually an environment variable) and maps it to a type. When a hosting platform is active but its value is unrecognised, the [fallback](#configuration) (`development` by default) applies - except where the table notes otherwise.
+
+| Platform | Signal | `production` | `stage` | `development` | `preview` |
+|----------|--------|--------------|---------|---------------|-----------|
+| Acquia | `AH_SITE_ENVIRONMENT` | `prod` | `stage`, `test` | `dev` | `ode*` (on-demand) |
+| Lagoon | `LAGOON_KUBERNETES` | env-type `production`, or branch matching `ENVIRONMENT_PRODUCTION_BRANCH` | `main`/`master`, `release/*`, `hotfix/*` | env-type `development` | - |
+| Pantheon | `PANTHEON_ENVIRONMENT` | `live` | `test` | `dev` | any other value (multidev); no fallback |
+| Platform.sh | `PLATFORM_ENVIRONMENT_TYPE` | `production` | `staging` | `development` | - |
+| Skpr | `SKPR_ENV` | `prod` | `stg` | `dev` | - |
+| Tugboat | `TUGBOAT_PREVIEW_ID` | - | - | - | always |
+
+The CI platforms - CircleCI, GitHub Actions, GitLab CI - always resolve to `ci`.
 
 Read the active platform:
 

--- a/src/Platforms/Acquia.php
+++ b/src/Platforms/Acquia.php
@@ -29,9 +29,17 @@ class Acquia extends AbstractPlatform {
    * {@inheritdoc}
    */
   public function type(): ?string {
-    return match (getenv('AH_SITE_ENVIRONMENT')) {
+    $env = getenv('AH_SITE_ENVIRONMENT');
+
+    // On-demand (Continuous Delivery) environments are ephemeral previews
+    // whose names are not fixed, but Acquia prefixes them with 'ode'.
+    if (is_string($env) && str_starts_with($env, 'ode')) {
+      return Environment::PREVIEW;
+    }
+
+    return match ($env) {
       'dev' => Environment::DEVELOPMENT,
-      'test' => Environment::STAGE,
+      'stage', 'test' => Environment::STAGE,
       'prod' => Environment::PRODUCTION,
       default => NULL,
     };

--- a/tests/Platforms/AcquiaTest.php
+++ b/tests/Platforms/AcquiaTest.php
@@ -38,10 +38,38 @@ final class AcquiaTest extends PlatformTestCase {
       },
     ];
     yield [
+      fn() => self::envSet('AH_SITE_ENVIRONMENT', 'stage'),
+      Environment::STAGE,
+      function ($test): void {
+          $test->assertTrue(Environment::isStage());
+      },
+    ];
+    yield [
       fn() => self::envSet('AH_SITE_ENVIRONMENT', 'prod'),
       Environment::PRODUCTION,
       function ($test): void {
           $test->assertTrue(Environment::isProd());
+      },
+    ];
+    yield [
+      fn() => self::envSet('AH_SITE_ENVIRONMENT', 'ode123'),
+      Environment::PREVIEW,
+      function ($test): void {
+          $test->assertTrue(Environment::isPreview());
+      },
+    ];
+    yield [
+      fn() => self::envSet('AH_SITE_ENVIRONMENT', 'ode'),
+      Environment::PREVIEW,
+      function ($test): void {
+          $test->assertTrue(Environment::isPreview());
+      },
+    ];
+    yield [
+      fn() => self::envSet('AH_SITE_ENVIRONMENT', 'something'),
+      NULL,
+      function ($test): void {
+          $test->assertTrue(Environment::isDev());
       },
     ];
   }


### PR DESCRIPTION
Closes #79

## Summary

The Acquia platform previously recognised only `dev`, `test`, and `prod` as `AH_SITE_ENVIRONMENT` values, so a site deployed to `stage` (Acquia's named staging tier) or an on-demand Continuous Delivery environment (whose names begin with `ode`) silently fell through to the `development` fallback - applying development-grade config to a staging or ephemeral-preview environment. This change maps `stage` to the `stage` type alongside `test`, and maps any `ode*` value to `preview`. The README now documents the environment-type vocabulary with a table and includes a per-platform mapping table showing how each built-in hosting platform resolves its signal to a type. Follow-up issue #80 tracks making `preview` detection systematic across all platforms with configurable branch and environment defaults.

## Changes

- Acquia platform (`src/Platforms/Acquia.php`): added an `ode*` prefix check that returns `preview` before the `match`, and added `'stage'` as a second arm alongside `'test'` for the `stage` type; the `default => NULL` fallback (which resolves to `development`) is preserved for any unrecognised value.
- Tests (`tests/Platforms/AcquiaTest.php`): added data-provider cases for `stage` -> stage, `ode123` -> preview, `ode` -> preview, and `something` -> development fallback (NULL platform type resolved to `development` by the environment).
- README (`README.md`): new "Environment types" vocabulary table listing all six built-in types with descriptions and lifespans, and a "How platforms map to types" table showing each hosting platform's signal and its type mappings; added a one-line scoping note that the types list applies to the built-in detectors.

## Before / After

```
AH_SITE_ENVIRONMENT mapping - BEFORE
┌────────────────────────────┬─────────────────────┐
│ AH_SITE_ENVIRONMENT value  │ Resolved type       │
├────────────────────────────┼─────────────────────┤
│ dev                        │ development         │
│ test                       │ stage               │
│ prod                       │ production          │
│ stage          (MISSING)   │ development (wrong) │
│ ode*, ode123   (MISSING)   │ development (wrong) │
│ <unknown>                  │ development         │
└────────────────────────────┴─────────────────────┘

AH_SITE_ENVIRONMENT mapping - AFTER
┌────────────────────────────┬─────────────────────┐
│ AH_SITE_ENVIRONMENT value  │ Resolved type       │
├────────────────────────────┼─────────────────────┤
│ dev                        │ development         │
│ test                       │ stage               │
│ stage          (NEW)       │ stage               │
│ prod                       │ production          │
│ ode*, ode123   (NEW)       │ preview             │
│ <unknown>                  │ development         │
└────────────────────────────┴─────────────────────┘
```
