### PR TITLE
Apply Acquia and container Drupal context settings and make the Lagoon region configurable

### DIFF
--- a/src/Platforms/Acquia.php
+++ b/src/Platforms/Acquia.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\EnvironmentDetector\Platforms;
 
+use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
+use DrevOps\EnvironmentDetector\Contexts\Drupal;
 use DrevOps\EnvironmentDetector\Environment;
 
 /**
@@ -43,6 +45,56 @@ class Acquia extends AbstractPlatform {
       'prod' => Environment::PRODUCTION,
       default => NULL,
     };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function contextualize(ContextInterface $context): void {
+    if (!$context instanceof Drupal) {
+      return;
+    }
+
+    global $settings;
+    global $config;
+
+    // Delay the initial database connection.
+    $config['acquia_hosting_settings_autoconnect'] = FALSE;
+
+    // Let Drupal create an .htaccess file in writable directories.
+    $settings['auto_create_htaccess'] = TRUE;
+
+    $group = getenv('AH_SITE_GROUP');
+
+    // Include the Acquia-provided settings file for the site group. It defines,
+    // among other things, the config_vcs_directory read below.
+    if (is_string($group) && $group !== '') {
+      $file = getenv('DRUPAL_ACQUIA_SETTINGS_FILE') ?: sprintf('/var/www/site-php/%s/%s-settings.inc', $group, $group);
+      // @codeCoverageIgnoreStart
+      if (is_string($file) && file_exists($file)) {
+        require $file;
+      }
+      // @codeCoverageIgnoreEnd
+    }
+
+    // Prefer the explicit config path, then the Acquia-provided VCS directory.
+    $config_path = getenv('DRUPAL_CONFIG_PATH');
+    if (is_string($config_path) && $config_path !== '') {
+      $settings['config_sync_directory'] = $config_path;
+    }
+    elseif (is_array($settings) && !empty($settings['config_vcs_directory'])) {
+      $settings['config_sync_directory'] = $settings['config_vcs_directory'];
+    }
+
+    // Temporary files location.
+    $settings['file_temp_path'] = '/tmp';
+    if (is_string($group) && $group !== '' && getenv('DRUPAL_TMP_PATH_IS_SHARED')) {
+      $settings['file_temp_path'] = sprintf('/mnt/gfs/%s.%s/tmp', $group, (string) getenv('AH_SITE_ENVIRONMENT'));
+    }
+    $tmp_path = getenv('DRUPAL_TMP_PATH');
+    if (is_string($tmp_path) && $tmp_path !== '') {
+      $settings['file_temp_path'] = $tmp_path;
+    }
   }
 
 }

--- a/src/Platforms/Lagoon.php
+++ b/src/Platforms/Lagoon.php
@@ -81,8 +81,16 @@ class Lagoon extends AbstractPlatform {
     // URL when accessed from PHP processes in Lagoon.
     $settings['trusted_host_patterns'][] = '^nginx\-php$';
 
-    // Public Lagoon URL.
-    $settings['trusted_host_patterns'][] = '^.+\.au\.amazee\.io$';
+    // Public Lagoon URL. The amazee.io region defaults to 'au' for backward
+    // compatibility; set LAGOON_AMAZEEIO_REGION to another region code, or to
+    // an empty string to skip this pattern.
+    $region = getenv('LAGOON_AMAZEEIO_REGION');
+    if ($region === FALSE) {
+      $region = 'au';
+    }
+    if ($region !== '') {
+      $settings['trusted_host_patterns'][] = '^.+\.' . preg_quote($region, '/') . '\.amazee\.io$';
+    }
 
     // Turn the comma-separated LAGOON_ROUTES URL list into one anchored
     // trusted-host regex: escape dots, drop the scheme, and let the commas

--- a/src/Stacks/Container.php
+++ b/src/Stacks/Container.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace DrevOps\EnvironmentDetector\Stacks;
 
+use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
+use DrevOps\EnvironmentDetector\Contexts\Drupal;
+
 /**
  * Container stack (generic containerisation).
  *
@@ -53,6 +56,28 @@ class Container extends AbstractStack {
     }
     // @codeCoverageIgnoreEnd
     return str_contains($cgroup, 'docker') || str_contains($cgroup, 'kubepods');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function contextualize(ContextInterface $context): void {
+    if (!$context instanceof Drupal) {
+      return;
+    }
+
+    global $settings;
+
+    // Build a trusted host pattern from a comma-separated list of local
+    // development hostnames or URLs (the dev domain plus any internal service
+    // names). Mirrors the LAGOON_ROUTES handling.
+    $hosts = getenv('DRUPAL_DEV_TRUSTED_HOSTS');
+    if (is_string($hosts) && $hosts !== '') {
+      $patterns = str_replace(['.', 'https://', 'http://', ','], [
+        '\.', '', '', '|',
+      ], $hosts);
+      $settings['trusted_host_patterns'][] = '^(' . $patterns . ')$';
+    }
   }
 
 }

--- a/tests/Platforms/AcquiaTest.php
+++ b/tests/Platforms/AcquiaTest.php
@@ -6,7 +6,9 @@ namespace DrevOps\EnvironmentDetector\Tests\Platforms;
 
 use DrevOps\EnvironmentDetector\Environment;
 use DrevOps\EnvironmentDetector\Platforms\Acquia;
+use DrevOps\EnvironmentDetector\Tests\Fixtures\NotDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Acquia::class)]
@@ -71,6 +73,138 @@ final class AcquiaTest extends PlatformTestCase {
       function ($test): void {
           $test->assertTrue(Environment::isDev());
       },
+    ];
+  }
+
+  public function testContextualizeNonDrupalIsNoop(): void {
+    self::envSet('AH_SITE_ENVIRONMENT', 'prod');
+
+    global $settings;
+    global $config;
+    $settings = [];
+    $config = [];
+
+    // A non-Drupal context must not trigger any settings injection.
+    (new Acquia())->contextualize(new NotDrupalContext());
+
+    $this->assertSame([], $settings);
+    $this->assertSame([], $config);
+  }
+
+  #[DataProvider('dataProviderContextualizeDrupal')]
+  public function testContextualizeDrupal(callable $before, array $expected): void {
+    $before();
+
+    self::envSet('AH_SITE_ENVIRONMENT', 'dev');
+    Environment::init();
+
+    global $settings;
+    global $config;
+
+    $this->assertEquals($expected['settings'], $settings);
+    $this->assertEquals($expected['config'], $config);
+  }
+
+  public static function dataProviderContextualizeDrupal(): \Iterator {
+    $config = [
+      'acquia_hosting_settings_autoconnect' => FALSE,
+    ];
+    // Minimal: no group, no config path, no temp overrides.
+    yield [
+      function (): void {
+        global $settings;
+        global $config;
+        $settings = ['hash_salt' => 'abc'];
+        $config = [];
+      },
+      [
+        'settings' => [
+          'hash_salt' => 'abc',
+          'environment' => Environment::DEVELOPMENT,
+          'auto_create_htaccess' => TRUE,
+          'file_temp_path' => '/tmp',
+        ],
+        'config' => $config,
+      ],
+    ];
+    // Explicit config sync path.
+    yield [
+      function (): void {
+        global $settings;
+        global $config;
+        $settings = ['hash_salt' => 'abc'];
+        $config = [];
+        self::envSet('DRUPAL_CONFIG_PATH', '/app/config/sync');
+      },
+      [
+        'settings' => [
+          'hash_salt' => 'abc',
+          'environment' => Environment::DEVELOPMENT,
+          'auto_create_htaccess' => TRUE,
+          'config_sync_directory' => '/app/config/sync',
+          'file_temp_path' => '/tmp',
+        ],
+        'config' => $config,
+      ],
+    ];
+    // Acquia-provided VCS directory fallback.
+    yield [
+      function (): void {
+        global $settings;
+        global $config;
+        $settings = ['hash_salt' => 'abc', 'config_vcs_directory' => '/var/www/config'];
+        $config = [];
+      },
+      [
+        'settings' => [
+          'hash_salt' => 'abc',
+          'config_vcs_directory' => '/var/www/config',
+          'environment' => Environment::DEVELOPMENT,
+          'auto_create_htaccess' => TRUE,
+          'config_sync_directory' => '/var/www/config',
+          'file_temp_path' => '/tmp',
+        ],
+        'config' => $config,
+      ],
+    ];
+    // Explicit temp path override.
+    yield [
+      function (): void {
+        global $settings;
+        global $config;
+        $settings = ['hash_salt' => 'abc'];
+        $config = [];
+        self::envSet('DRUPAL_TMP_PATH', '/custom/tmp');
+      },
+      [
+        'settings' => [
+          'hash_salt' => 'abc',
+          'environment' => Environment::DEVELOPMENT,
+          'auto_create_htaccess' => TRUE,
+          'file_temp_path' => '/custom/tmp',
+        ],
+        'config' => $config,
+      ],
+    ];
+    // Shared temp path derived from the site group and environment.
+    yield [
+      function (): void {
+        global $settings;
+        global $config;
+        $settings = ['hash_salt' => 'abc'];
+        $config = [];
+        self::envSet('AH_SITE_GROUP', 'mygroup');
+        self::envSet('DRUPAL_TMP_PATH_IS_SHARED', '1');
+      },
+      [
+        'settings' => [
+          'hash_salt' => 'abc',
+          'environment' => Environment::DEVELOPMENT,
+          'auto_create_htaccess' => TRUE,
+          'file_temp_path' => '/mnt/gfs/mygroup.dev/tmp',
+        ],
+        'config' => $config,
+      ],
     ];
   }
 

--- a/tests/Platforms/LagoonTest.php
+++ b/tests/Platforms/LagoonTest.php
@@ -252,6 +252,45 @@ final class LagoonTest extends PlatformTestCase {
           'config' => array_merge_recursive([], $default_config),
         ],
       ],
+      [
+        function () use ($default_settings, $default_config): void {
+          global $settings;
+          global $config;
+          $settings = $default_settings;
+          $config = $default_config;
+          self::envSet('LAGOON_AMAZEEIO_REGION', 'us');
+        },
+        [
+          'settings' => array_merge_recursive([
+            'reverse_proxy' => TRUE,
+            'reverse_proxy_header' => 'HTTP_TRUE_CLIENT_IP',
+            'trusted_host_patterns' => [
+              '^nginx\-php$',
+              '^.+\.us\.amazee\.io$',
+            ],
+          ] + $default_settings),
+          'config' => array_merge_recursive([], $default_config),
+        ],
+      ],
+      [
+        function () use ($default_settings, $default_config): void {
+          global $settings;
+          global $config;
+          $settings = $default_settings;
+          $config = $default_config;
+          self::envSet('LAGOON_AMAZEEIO_REGION', '');
+        },
+        [
+          'settings' => array_merge_recursive([
+            'reverse_proxy' => TRUE,
+            'reverse_proxy_header' => 'HTTP_TRUE_CLIENT_IP',
+            'trusted_host_patterns' => [
+              '^nginx\-php$',
+            ],
+          ] + $default_settings),
+          'config' => array_merge_recursive([], $default_config),
+        ],
+      ],
     ];
   }
 

--- a/tests/Stacks/ContainerTest.php
+++ b/tests/Stacks/ContainerTest.php
@@ -6,7 +6,9 @@ namespace DrevOps\EnvironmentDetector\Tests\Stacks;
 
 use DrevOps\EnvironmentDetector\Environment;
 use DrevOps\EnvironmentDetector\Stacks\Container;
+use DrevOps\EnvironmentDetector\Tests\Fixtures\NotDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(Container::class)]
 #[CoversClass(Environment::class)]
@@ -51,6 +53,60 @@ final class ContainerTest extends StackTestCase {
 
     // A more specific container is detected ahead of the generic one.
     $this->assertSame('ddev', Environment::getActiveStack()?->id());
+  }
+
+  public function testContextualizeNonDrupalIsNoop(): void {
+    self::envSet('DOCKER', 'TRUE');
+    self::envSet('DRUPAL_DEV_TRUSTED_HOSTS', 'https://example.local,webserver');
+
+    global $settings;
+    $settings = [];
+
+    // A non-Drupal context must not trigger any settings injection.
+    (new Container())->contextualize(new NotDrupalContext());
+
+    $this->assertSame([], $settings);
+  }
+
+  #[DataProvider('dataProviderContextualizeDrupal')]
+  public function testContextualizeDrupal(callable $before, array $expected): void {
+    $before();
+
+    self::envSet('DOCKER', 'TRUE');
+    Environment::init();
+
+    global $settings;
+
+    $this->assertEquals($expected, $settings);
+  }
+
+  public static function dataProviderContextualizeDrupal(): \Iterator {
+    // No trusted host list - nothing added beyond the resolved environment.
+    yield [
+      function (): void {
+          global $settings;
+          $settings = ['hash_salt' => 'abc'];
+      },
+        [
+          'hash_salt' => 'abc',
+          'environment' => Environment::LOCAL,
+        ],
+    ];
+    // A comma-separated URL/host list becomes one trusted-host regex.
+    yield [
+      function (): void {
+          global $settings;
+          $settings = ['hash_salt' => 'abc'];
+          self::envSet('DRUPAL_DEV_TRUSTED_HOSTS', 'https://mysite.local,webserver');
+      },
+        [
+          'hash_salt' => 'abc',
+          'environment' => Environment::LOCAL,
+          'trusted_host_patterns' => [
+            '^(mysite\.local|webserver)$',
+          ],
+        ],
+    ];
   }
 
 }


### PR DESCRIPTION
## Summary

Move provider-specific Drupal settings into the platforms and the container stack so the detector fully owns them. Consumers (e.g. Vortex) can then delegate these settings to the package instead of re-implementing them in their own `settings.php`. Each platform/stack applies its settings via `contextualize()` only when the active context is Drupal.

Closes #82, closes #83, closes #84.

## Changes

### Acquia (#82)

`Acquia::contextualize()` (new) applies, for a Drupal context:

- `$config['acquia_hosting_settings_autoconnect'] = FALSE`
- `$settings['auto_create_htaccess'] = TRUE`
- includes the Acquia-provided `/var/www/site-php/<group>/<group>-settings.inc` (overridable via `DRUPAL_ACQUIA_SETTINGS_FILE`)
- `config_sync_directory` from `DRUPAL_CONFIG_PATH`, falling back to the `config_vcs_directory` defined by the include
- `file_temp_path` (`/tmp`, `/mnt/gfs/<group>.<env>/tmp` when `DRUPAL_TMP_PATH_IS_SHARED`, or `DRUPAL_TMP_PATH`)

### Lagoon (#83)

The amazee.io trusted-host region is now configurable via `LAGOON_AMAZEEIO_REGION`: unset → `au` (backward compatible), empty string → skip the pattern, otherwise the given region code.

### Container (#84)

`Container::contextualize()` (new) appends a trusted-host pattern built from a comma-separated `DRUPAL_DEV_TRUSTED_HOSTS` list (the local dev domain plus any internal service hostnames), mirroring the existing `LAGOON_ROUTES` handling. This is the most consumer-specific of the three - happy to adjust the variable name or shape.

## Tests

Added `contextualize()` coverage for Acquia and Container (including the non-Drupal no-op), and Lagoon region cases (custom region and empty-skip). Full suite is green (230 tests) and `composer lint` is clean.

## Before / After

```
Acquia / Container platform-stack rings:

BEFORE                                   AFTER
  type()  -> resolves environment type     type()  -> resolves environment type
  contextualize() -> noop                  contextualize() -> applies Drupal settings
  (consumer re-implements settings)        (detector owns the settings)

Lagoon trusted host:

BEFORE  ^.+\.au\.amazee\.io$  (hardcoded au)
AFTER   ^.+\.<region>\.amazee\.io$  (LAGOON_AMAZEEIO_REGION, default au, empty skips)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Drupal environment setup for supported hosting platforms, including smarter handling of config sync, temporary files, and trusted host settings.
  * Added support for region-aware host allowlists on Lagoon, with improved compatibility for different deployment regions.
  * Expanded container-based Drupal settings to accept custom trusted host entries from environment configuration.

* **Bug Fixes**
  * Better handling of non-Drupal contexts so unrelated settings are no longer applied unexpectedly.
  * Added broader test coverage for common hosting and environment combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->