### PR TITLE
Documented consumer-settable environment variables and renamed the container trusted-hosts variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,23 @@ class CustomContext implements ContextInterface {
 Environment::init(contexts: [new CustomContext()]);
 ```
 
+## Environment variables
+
+Beyond the platform and stack detection signals the hosting or CI provider sets (listed in the [Platforms](#platforms) table), the detector reads a few variables that **you** set - to override detection or to shape the settings a context applies. All are optional.
+
+| Variable | Effect | Applies to | When unset |
+|----------|--------|------------|------------|
+| `ENVIRONMENT_TYPE` | If set before detection, the value is used verbatim and overrides all detection (handy for forcing a type while debugging); the resolved type is written back here either way. | Core | Detection runs and populates it. |
+| `CI` | When no platform is active, a truthy value resolves the type to `ci` instead of `local`. Most CI providers set it automatically. | Core | Treated as not-CI, so `local`. |
+| `ENVIRONMENT_PRODUCTION_BRANCH` | Names the Git branch deployed as production: a deployed branch equal to it resolves to `production`, and it also forms the Drupal `cache_prefix`. | Lagoon | Branches are typed by built-in conventions only. |
+| `DRUPAL_CONFIG_PATH` | Sets the Drupal `config_sync_directory`. | Acquia | Falls back to the Acquia-provided `config_vcs_directory`. |
+| `DRUPAL_TMP_PATH` | Sets the Drupal `file_temp_path` explicitly; takes precedence over the shared path below. | Acquia | `/tmp`, or the shared path when `DRUPAL_TMP_PATH_IS_SHARED` is set. |
+| `DRUPAL_TMP_PATH_IS_SHARED` | When truthy, points `file_temp_path` at the shared GFS mount (`/mnt/gfs/<group>.<env>/tmp`). | Acquia | `file_temp_path` stays `/tmp`. |
+| `DRUPAL_ACQUIA_SETTINGS_FILE` | Overrides the path to the Acquia-provided `*-settings.inc` file that is included. | Acquia | `/var/www/site-php/<group>/<group>-settings.inc`. |
+| `DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS` | A comma-separated list of hostnames or URLs added as a Drupal `trusted_host_patterns` entry. | Container stack | No pattern is added. |
+
+The `DRUPAL_*` variables take effect only when the [Drupal](#contexts) context is active.
+
 ## Maintenance
 
 ```bash

--- a/src/Stacks/Container.php
+++ b/src/Stacks/Container.php
@@ -68,10 +68,10 @@ class Container extends AbstractStack {
 
     global $settings;
 
-    // Build a trusted host pattern from a comma-separated list of local
-    // development hostnames or URLs (the dev domain plus any internal service
-    // names). Mirrors the LAGOON_ROUTES handling.
-    $hosts = getenv('DRUPAL_DEV_TRUSTED_HOSTS');
+    // Build a trusted host pattern from a comma-separated list of the
+    // container's hostnames or URLs (the site domain plus any internal
+    // service names). Mirrors the LAGOON_ROUTES handling.
+    $hosts = getenv('DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS');
     if (is_string($hosts) && $hosts !== '') {
       $patterns = str_replace(['.', 'https://', 'http://', ','], [
         '\.', '', '', '|',

--- a/tests/Stacks/ContainerTest.php
+++ b/tests/Stacks/ContainerTest.php
@@ -57,7 +57,7 @@ final class ContainerTest extends StackTestCase {
 
   public function testContextualizeNonDrupalIsNoop(): void {
     self::envSet('DOCKER', 'TRUE');
-    self::envSet('DRUPAL_DEV_TRUSTED_HOSTS', 'https://example.local,webserver');
+    self::envSet('DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS', 'https://example.local,webserver');
 
     global $settings;
     $settings = [];
@@ -97,7 +97,7 @@ final class ContainerTest extends StackTestCase {
       function (): void {
           global $settings;
           $settings = ['hash_salt' => 'abc'];
-          self::envSet('DRUPAL_DEV_TRUSTED_HOSTS', 'https://mysite.local,webserver');
+          self::envSet('DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS', 'https://mysite.local,webserver');
       },
         [
           'hash_salt' => 'abc',


### PR DESCRIPTION
## Summary

A new "Environment variables" section in the README documents the 8 consumer-settable environment variables the library reads, presented as a table with variable name, effect, which platform or stack it applies to, and what happens when it is not set. Separately, the trusted-hosts variable read by the container stack was renamed from `DRUPAL_DEV_TRUSTED_HOSTS` to `DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS` so it follows the same `DRUPAL_ENVIRONMENT_*` naming pattern used elsewhere and is no longer scoped to "dev" only. The adjacent code comment was updated to match.

## Changes

**README.md** - added a new `## Environment variables` section between the "Custom Context" code example and the "Maintenance" section. The section contains a prose introduction and a table with four columns (Variable / Effect / Applies to / When unset) covering: `ENVIRONMENT_TYPE`, `CI`, `ENVIRONMENT_PRODUCTION_BRANCH`, `DRUPAL_CONFIG_PATH`, `DRUPAL_TMP_PATH`, `DRUPAL_TMP_PATH_IS_SHARED`, `DRUPAL_ACQUIA_SETTINGS_FILE`, and `DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS`. A closing note clarifies that `DRUPAL_*` variables only take effect when the Drupal context is active.

**src/Stacks/Container.php** - renamed the `getenv()` call from `DRUPAL_DEV_TRUSTED_HOSTS` to `DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS`; updated the adjacent comment to drop the "local development" framing and refer to "container's hostnames or URLs" instead.

**tests/Stacks/ContainerTest.php** - updated the two `self::envSet()` calls that reference the old variable name to use `DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS`.

## Breaking change

Any consumer currently setting the `DRUPAL_DEV_TRUSTED_HOSTS` environment variable must switch to `DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS`. The old name is no longer read by the library and settings that depended on it will silently have no effect until the variable is renamed.

## Before / After

```
Before                                   After
────────────────────────────────────     ────────────────────────────────────────────────────
Variable name in Container.php:          Variable name in Container.php:
  DRUPAL_DEV_TRUSTED_HOSTS                 DRUPAL_ENVIRONMENT_CONTAINER_TRUSTED_HOSTS

README structure (after "Custom          README structure (after "Custom Context"):
Context"):                                 ## Environment variables   ← NEW SECTION
  ## Maintenance                             | Variable | Effect | Applies to | When unset |
                                             | ...      | ...    | ...        | ...        |
                                           ## Maintenance
```
