### PR TITLE
Made README and context interface docs framework-agnostic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ A run is a set of nested rings, from the outermost ring inward to the applicatio
 ```
 
 - **Platform** - the outermost ring, and the *only* one that decides the type. A hosting platform maps to `production`/`stage`/`development`/`preview`; a CI platform maps to `ci`; with no platform at all the type is `local` (or `ci` when a generic `CI` signal is present).
-- **Stack** - the substrate the run sits in (`native`, `container`, `ddev`, `lando`). A stack nests inside a platform, never decides the type, and only contributes settings. `ddev` and `lando` are specific containers, `container` is the generic container fallback, and `native` is the native host (bare metal), the fallback when nothing else matches.
-- **Context** - the application/framework (e.g. Drupal) that detected settings are applied to.
+- **Stack** - the substrate the run sits in (`native`, `container`, `ddev`, `lando`). A stack nests inside a platform, never decides the type, and can only update the context. `ddev` and `lando` are specific containers, `container` is the generic container fallback, and `native` is the native host (bare metal), the fallback when nothing else matches.
+- **Context** - the application/framework (e.g. Drupal, WordPress, Laravel) that detected settings are applied to.
 - **Runtime** (PHP) is shown only to complete the picture; it is not detected.
 
 Two rules follow:
@@ -120,7 +120,7 @@ Two rules follow:
 1. **At most one platform is active.** Two active platforms (say Acquia *and* Lagoon) is a genuine misconfiguration and throws.
 2. **Exactly one stack is always active - the most specific stack that matches, or the native host as the fallback.** A container inside Acquia or inside CI is just an inner ring; it never collides with the platform. The most specific match wins - DDEV over the generic `container`, say - and the native host is the last-resort fallback when nothing else matches.
 
-When a context is active, it applies its generic settings first, then the active platform and the active stack apply their own on top. This happens even when the type was pre-set via `ENVIRONMENT_TYPE`.
+When a context is active, it applies its own generic changes first, then the active platform and the active stack apply their own on top. This happens even when the type was pre-set via `ENVIRONMENT_TYPE`.
 
 ## Configuration
 
@@ -260,9 +260,11 @@ Environment::init(stacks: [new CustomStack()]);
 
 ## Contexts
 
-A context is the framework or application that detected settings are applied to. Once a context is active it applies its own generic settings first, then the active platform and the active stack layer their changes on top of the same target (the Lagoon platform, say, adds its reverse-proxy and trusted-host settings).
+A context is the framework or application that detected settings are applied to. Once a context is active it applies its own generic changes first, then the active platform and the active stack layer their changes on top of the same target (the Lagoon platform, say, adds its reverse-proxy and trusted-host settings).
 
 The built-in [Drupal](src/Contexts/Drupal.php) context is the turnkey example: it holds the site's `$settings` and `$config` by reference and is wired up by the one-line [Drupal integration](#drupal) shown above.
+
+Drupal is the only built-in context today, but the ring model is framework-agnostic. We are looking to add more framework integrations - contributions that add contexts for other frameworks (WordPress, Laravel, Symfony, and more) are welcome. Open an issue or a pull request.
 
 ### Custom contexts
 

--- a/README.md
+++ b/README.md
@@ -268,12 +268,20 @@ Drupal is the only built-in context today, but the ring model is framework-agnos
 
 ### Custom contexts
 
-Add your own by implementing `ContextInterface`:
+Add your own by implementing `ContextInterface`. Bind the framework's own state by reference in the constructor, then write to it in `contextualize()` - the same by-reference approach the built-in Drupal context uses:
 
 ```php
 use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
 
 class CustomContext implements ContextInterface {
+  // Hold the framework's own config by reference so the changes land in the
+  // array the framework reads back, not a separate copy.
+  public array $config;
+
+  public function __construct(array &$config = []) {
+    $this->config = &$config;
+  }
+
   public function id(): string {
     return 'myframework';
   }
@@ -283,12 +291,12 @@ class CustomContext implements ContextInterface {
   }
 
   public function contextualize(): void {
-    global $configuration;
-    $configuration['custom_value'] = $_SERVER['custom_value'] ?? 'default';
+    $this->config['custom_value'] = $_SERVER['custom_value'] ?? 'default';
   }
 }
 
-Environment::init(contexts: [new CustomContext()]);
+// $config is the framework's own configuration array, in scope here.
+Environment::init(contexts: [new CustomContext($config)]);
 ```
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ A context is the framework or application that detected settings are applied to.
 
 The built-in [Drupal](src/Contexts/Drupal.php) context is the turnkey example: it holds the site's `$settings` and `$config` by reference and is wired up by the one-line [Drupal integration](#drupal) shown above.
 
-Drupal is the only built-in context today, but the ring model is framework-agnostic. We are looking to add more framework integrations - contributions that add contexts for other frameworks (WordPress, Laravel, Symfony, and more) are welcome. Open an issue or a pull request.
+> [!NOTE]
+> Drupal is the only built-in context today, but the ring model is framework-agnostic. We are looking to add more framework integrations - contributions that add contexts for other frameworks (WordPress, Laravel, Symfony, and more) are welcome. Open an issue or a pull request.
 
 ### Custom contexts
 

--- a/src/Contexts/ContextInterface.php
+++ b/src/Contexts/ContextInterface.php
@@ -27,9 +27,9 @@ interface ContextInterface {
   /**
    * Check if the context is active.
    *
-   * Any required data _could_ be passed in as an argument, but better to use
-   * the other means based on the implementation: environment variables,
-   * configuration files, global variables, etc.
+   * The method takes no arguments; an implementation reads whatever it needs
+   * from the state it holds (for example values injected at construction),
+   * environment variables, or configuration files.
    *
    * @return bool
    *   TRUE if the context is active, FALSE otherwise.
@@ -39,9 +39,10 @@ interface ContextInterface {
   /**
    * Apply the context.
    *
-   * Any data that needs to be modified _could_ be passed in as an argument,
-   * but better to use the other means based on the implementation: environment
-   * variables, configuration files, global variables, etc.
+   * The method takes no arguments; an implementation applies changes to the
+   * state it holds (for example framework settings injected by reference at
+   * construction, so the changes land in the arrays the framework reads back),
+   * environment variables, or configuration files.
    */
   public function contextualize(): void;
 


### PR DESCRIPTION
## Summary

The README "How it works" and Contexts sections were reworded to be framework-agnostic: Drupal-flavoured "settings" language was replaced with "context" and "changes", and WordPress and Laravel are now named alongside Drupal as example framework contexts. The custom-context code example was rewritten to use the by-reference constructor pattern (matching the built-in `src/Contexts/Drupal.php`) instead of `global $configuration`. A GitHub `[!NOTE]` admonition was added inviting contributions for additional framework integrations. The `ContextInterface` `active()` and `contextualize()` docblocks were updated to drop the stale "global variables" recommendation and describe the by-reference design.

## Changes

### Documentation (`README.md`)

- Replaced "detected settings are applied to" with "detected settings are applied to (e.g. Drupal, WordPress, Laravel)" in the rings description.
- Changed "can only update the context" to "never decides the type, and can only update the context" in the Stack bullet.
- Reworded the context-activation sentence to say "applies its own generic changes" rather than "applies its generic settings".
- Replaced the `global $configuration` custom-context example with a constructor that binds `$config` by reference and writes `$this->config` in `contextualize()`, matching the Drupal built-in.
- Added a `[!NOTE]` admonition noting Drupal is the only built-in context today and inviting contributions for WordPress, Laravel, Symfony, and others.

### Source docblocks (`src/Contexts/ContextInterface.php`)

- `active()` docblock: removed the "global variables" suggestion; replaced it with a description of reading from constructor-injected state, environment variables, or config files.
- `contextualize()` docblock: removed the "global variables" suggestion; replaced it with a description of writing to by-reference constructor-injected state so changes land in the arrays the framework reads back.

## Related

Follow-up integration issues opened from the new contributions note: #95 (WordPress) and #96 (Laravel). Not closed by this PR.

## Before / After

```
BEFORE - custom context example (global variable pattern)
┌─────────────────────────────────────────────────────────────┐
│ class CustomContext implements ContextInterface {           │
│   public function id(): string { return 'myframework'; }   │
│   public function active(): bool { return true; }          │
│   public function contextualize(): void {                   │
│     global $configuration;                                  │
│     $configuration['custom_value'] = $_SERVER[...] ?? ...; │
│   }                                                         │
│ }                                                           │
│ Environment::init(contexts: [new CustomContext()]);         │
└─────────────────────────────────────────────────────────────┘

AFTER - custom context example (by-reference constructor pattern)
┌─────────────────────────────────────────────────────────────┐
│ class CustomContext implements ContextInterface {           │
│   public array $config;                                     │
│   public function __construct(array &$config = []) {        │
│     $this->config = &$config;   // bound by reference       │
│   }                                                         │
│   public function id(): string { return 'myframework'; }   │
│   public function active(): bool { return true; }          │
│   public function contextualize(): void {                   │
│     $this->config['custom_value'] = $_SERVER[...] ?? ...; │
│   }                                                         │
│ }                                                           │
│ // $config is the framework's own array, in scope here.    │
│ Environment::init(contexts: [new CustomContext($config)]);  │
└─────────────────────────────────────────────────────────────┘

Changes land directly in the framework's own array (not a copy),
matching the pattern used by the built-in Drupal context.
```
