### PR TITLE
[#92] Added 'DrupalContextualizerInterface' for typed per-context dispatch in platforms and stacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,16 @@ if (Environment::getActivePlatform()?->id() === 'acquia') {
 }
 ```
 
-Add your own by implementing `PlatformInterface`:
+Add your own by extending `AbstractPlatform`. Implement a context's capability interface (`DrupalContextualizerInterface` for Drupal) to apply settings through a typed method the detector resolves for you; override `contextualize()` to handle a context defined at runtime instead:
 
 ```php
-use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
+use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 use DrevOps\EnvironmentDetector\Environment;
-use DrevOps\EnvironmentDetector\Platforms\PlatformInterface;
+use DrevOps\EnvironmentDetector\Platforms\AbstractPlatform;
 
-class CustomHosting implements PlatformInterface {
-  public function id(): string {
-    return 'customhosting';
-  }
+class CustomHosting extends AbstractPlatform implements DrupalContextualizerInterface {
+  public const ID = 'customhosting';
 
   public function active(): bool {
     return isset($_SERVER['CUSTOM_ENV']);
@@ -206,8 +205,10 @@ class CustomHosting implements PlatformInterface {
     };
   }
 
-  public function contextualize(ContextInterface $context): void {
-    // Optional: apply platform-specific context changes.
+  // Resolved automatically for the Drupal context. To handle a context defined
+  // at runtime, override contextualize(ContextInterface $context) instead.
+  public function contextualizeDrupal(Drupal $context): void {
+    $context->settings['some_setting'] = 'value';
   }
 }
 
@@ -235,23 +236,24 @@ if (Environment::getActiveStack()?->id() === 'ddev') {
 
 `getActiveStack()` returns the first registered stack whose `active()` matches - your custom stacks included - with the `native` host as the last-resort fallback.
 
-Add your own by implementing `StackInterface`:
+Add your own by extending `AbstractStack`. As with platforms, implement a context's capability interface for the typed path, or override `contextualize()` for a runtime context:
 
 ```php
-use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
-use DrevOps\EnvironmentDetector\Stacks\StackInterface;
+use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
+use DrevOps\EnvironmentDetector\Stacks\AbstractStack;
 
-class CustomStack implements StackInterface {
-  public function id(): string {
-    return 'customstack';
-  }
+class CustomStack extends AbstractStack implements DrupalContextualizerInterface {
+  public const ID = 'customstack';
 
   public function active(): bool {
     return getenv('CUSTOM_STACK') !== false;
   }
 
-  public function contextualize(ContextInterface $context): void {
-    // Optional: apply stack-specific context changes.
+  // Resolved automatically for the Drupal context. To handle a context defined
+  // at runtime, override contextualize(ContextInterface $context) instead.
+  public function contextualizeDrupal(Drupal $context): void {
+    $context->settings['some_setting'] = 'value';
   }
 }
 
@@ -261,6 +263,8 @@ Environment::init(stacks: [new CustomStack()]);
 ## Contexts
 
 A context is the framework or application that detected settings are applied to. Once a context is active it applies its own generic changes first, then the active platform and the active stack layer their changes on top of the same target (the Lagoon platform, say, adds its reverse-proxy and trusted-host settings).
+
+A platform or stack applies settings to a context in one of two ways. For a context the library ships, it implements that context's capability interface - [`DrupalContextualizerInterface`](src/Contexts/DrupalContextualizerInterface.php) for Drupal - and the detector resolves the typed `contextualizeDrupal()` method automatically. For a context defined at runtime, it overrides `contextualize(ContextInterface $context)` and handles the context itself. The built-in platforms and stacks use the typed path.
 
 The built-in [Drupal](src/Contexts/Drupal.php) context is the turnkey example: it holds the site's `$settings` and `$config` by reference and is wired up by the one-line [Drupal integration](#drupal) shown above.
 

--- a/src/Contexts/DrupalContextualizerInterface.php
+++ b/src/Contexts/DrupalContextualizerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\EnvironmentDetector\Contexts;
+
+/**
+ * Drupal contextualizer interface.
+ *
+ * A platform or stack implements this to apply settings to the Drupal context
+ * in a typed way: the detector calls contextualizeDrupal() with the active
+ * Drupal context, so an implementing ring needs no manual context type check.
+ *
+ * @package DrevOps\EnvironmentDetector\Contexts
+ */
+interface DrupalContextualizerInterface {
+
+  /**
+   * Apply settings to the Drupal context.
+   *
+   * @param \DrevOps\EnvironmentDetector\Contexts\Drupal $context
+   *   The Drupal context to apply settings to.
+   */
+  public function contextualizeDrupal(Drupal $context): void;
+
+}

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace DrevOps\EnvironmentDetector\Platforms;
 
 use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
+use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 
 /**
  * Abstract platform.
@@ -35,14 +37,23 @@ abstract class AbstractPlatform implements PlatformInterface {
   /**
    * {@inheritdoc}
    */
-  // phpcs:disable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
-  // phpcs:disable Drupal.Commenting.FunctionComment.WrongStyle
-  // phpcs:disable Squiz.WhiteSpace.FunctionSpacing.After
   public function contextualize(ContextInterface $context): void {
-    // Noop. Override to inject context-specific settings.
+    // Known interfaces - optimised for speed.
+    if ($this instanceof DrupalContextualizerInterface && $context instanceof Drupal) {
+      // Only the most-derived contextualizeDrupal() runs, so a subclass that
+      // overrides it must call parent::contextualizeDrupal() to keep the
+      // parent's settings.
+      $this->contextualizeDrupal($context);
+      return;
+    }
+
+    // Runtime.
+    $method = 'contextualize' . (new \ReflectionClass($context))->getShortName();
+    $callable = [$this, $method];
+
+    if (is_callable($callable)) {
+      $callable($context);
+    }
   }
-  // phpcs:enable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
-  // phpcs:enable Drupal.Commenting.FunctionComment.WrongStyle
-  // phpcs:enable Squiz.WhiteSpace.FunctionSpacing.After
 
 }

--- a/src/Platforms/Acquia.php
+++ b/src/Platforms/Acquia.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\EnvironmentDetector\Platforms;
 
-use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
 use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 use DrevOps\EnvironmentDetector\Environment;
 
 /**
@@ -13,7 +13,7 @@ use DrevOps\EnvironmentDetector\Environment;
  *
  * @package DrevOps\EnvironmentDetector\Platforms
  */
-class Acquia extends AbstractPlatform {
+class Acquia extends AbstractPlatform implements DrupalContextualizerInterface {
 
   /**
    * {@inheritdoc}
@@ -44,11 +44,7 @@ class Acquia extends AbstractPlatform {
   /**
    * {@inheritdoc}
    */
-  public function contextualize(ContextInterface $context): void {
-    if (!$context instanceof Drupal) {
-      return;
-    }
-
+  public function contextualizeDrupal(Drupal $context): void {
     $settings = &$context->settings;
     $config = &$context->config;
 

--- a/src/Platforms/Lagoon.php
+++ b/src/Platforms/Lagoon.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\EnvironmentDetector\Platforms;
 
-use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
 use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 use DrevOps\EnvironmentDetector\Environment;
 
 /**
@@ -13,7 +13,7 @@ use DrevOps\EnvironmentDetector\Environment;
  *
  * @package DrevOps\EnvironmentDetector\Platforms
  */
-class Lagoon extends AbstractPlatform {
+class Lagoon extends AbstractPlatform implements DrupalContextualizerInterface {
 
   /**
    * {@inheritdoc}
@@ -74,11 +74,7 @@ class Lagoon extends AbstractPlatform {
   /**
    * {@inheritdoc}
    */
-  public function contextualize(ContextInterface $context): void {
-    if (!$context instanceof Drupal) {
-      return;
-    }
-
+  public function contextualizeDrupal(Drupal $context): void {
     $settings = &$context->settings;
 
     // Lagoon reverse proxy settings.

--- a/src/Platforms/Skpr.php
+++ b/src/Platforms/Skpr.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\EnvironmentDetector\Platforms;
 
-use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
 use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 use DrevOps\EnvironmentDetector\Environment;
 use Skpr\SkprConfig;
 
@@ -14,7 +14,7 @@ use Skpr\SkprConfig;
  *
  * @package DrevOps\EnvironmentDetector\Platforms
  */
-class Skpr extends AbstractPlatform {
+class Skpr extends AbstractPlatform implements DrupalContextualizerInterface {
 
   /**
    * {@inheritdoc}
@@ -47,11 +47,7 @@ class Skpr extends AbstractPlatform {
    *
    * @see https://docs.skpr.io/integrations/drupal
    */
-  public function contextualize(ContextInterface $context): void {
-    if (!$context instanceof Drupal) {
-      return;
-    }
-
+  public function contextualizeDrupal(Drupal $context): void {
     // Outside a real Skpr+Drupal runtime there is nothing to configure. This
     // guard depends on runtime presence of SkprConfig and DRUPAL_ROOT, so it is
     // not exercisable from tests.

--- a/src/Stacks/AbstractStack.php
+++ b/src/Stacks/AbstractStack.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace DrevOps\EnvironmentDetector\Stacks;
 
 use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
+use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 
 /**
  * Abstract stack.
@@ -30,14 +32,23 @@ abstract class AbstractStack implements StackInterface {
   /**
    * {@inheritdoc}
    */
-  // phpcs:disable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
-  // phpcs:disable Drupal.Commenting.FunctionComment.WrongStyle
-  // phpcs:disable Squiz.WhiteSpace.FunctionSpacing.After
   public function contextualize(ContextInterface $context): void {
-    // Noop. Override to inject context-specific settings.
+    // Known interfaces - optimised for speed.
+    if ($this instanceof DrupalContextualizerInterface && $context instanceof Drupal) {
+      // Only the most-derived contextualizeDrupal() runs, so a subclass that
+      // overrides it must call parent::contextualizeDrupal() to keep the
+      // parent's settings.
+      $this->contextualizeDrupal($context);
+      return;
+    }
+
+    // Runtime.
+    $method = 'contextualize' . (new \ReflectionClass($context))->getShortName();
+    $callable = [$this, $method];
+
+    if (is_callable($callable)) {
+      $callable($context);
+    }
   }
-  // phpcs:enable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
-  // phpcs:enable Drupal.Commenting.FunctionComment.WrongStyle
-  // phpcs:enable Squiz.WhiteSpace.FunctionSpacing.After
 
 }

--- a/src/Stacks/Container.php
+++ b/src/Stacks/Container.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace DrevOps\EnvironmentDetector\Stacks;
 
-use DrevOps\EnvironmentDetector\Contexts\ContextInterface;
 use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 
 /**
  * Container stack (generic containerisation).
  *
  * @package DrevOps\EnvironmentDetector\Stacks
  */
-class Container extends AbstractStack {
+class Container extends AbstractStack implements DrupalContextualizerInterface {
 
   /**
    * {@inheritdoc}
@@ -68,11 +68,7 @@ class Container extends AbstractStack {
   /**
    * {@inheritdoc}
    */
-  public function contextualize(ContextInterface $context): void {
-    if (!$context instanceof Drupal) {
-      return;
-    }
-
+  public function contextualizeDrupal(Drupal $context): void {
     $settings = &$context->settings;
 
     // Internal service hostnames, reachable container-to-container.

--- a/tests/Platforms/AbstractPlatformTest.php
+++ b/tests/Platforms/AbstractPlatformTest.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace DrevOps\EnvironmentDetector\Tests\Platforms;
 
 use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 use DrevOps\EnvironmentDetector\Platforms\AbstractPlatform;
 use DrevOps\EnvironmentDetector\Tests\EnvironmentDetectorTestCase;
+use DrevOps\EnvironmentDetector\Tests\Fixtures\NotDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(AbstractPlatform::class)]
 final class AbstractPlatformTest extends EnvironmentDetectorTestCase {
 
   public function testIdDefaultsToConst(): void {
-    $platform = new class extends AbstractPlatform {
+    $platform = new class() extends AbstractPlatform {
 
       public function active(): bool {
         return FALSE;
@@ -28,8 +30,63 @@ final class AbstractPlatformTest extends EnvironmentDetectorTestCase {
     $this->assertSame('undefined', $platform->id());
   }
 
-  public function testContextualizeIsNoop(): void {
-    $platform = new class extends AbstractPlatform {
+  public function testContextualizeViaCapabilityInterface(): void {
+    $platform = new class() extends AbstractPlatform implements DrupalContextualizerInterface {
+
+      public function active(): bool {
+        return TRUE;
+      }
+
+      public function type(): ?string {
+        return NULL;
+      }
+
+      public function contextualizeDrupal(Drupal $context): void {
+        $context->settings['applied'] = 'drupal';
+      }
+
+    };
+
+    $settings = [];
+    $config = [];
+    $context = new Drupal($settings, $config);
+
+    $platform->contextualize($context);
+
+    // The typed capability interface is resolved and called directly.
+    $this->assertSame(['applied' => 'drupal'], $settings);
+  }
+
+  public function testContextualizeViaRuntimeReflection(): void {
+    $platform = new class() extends AbstractPlatform {
+
+      /**
+       * Records whether the runtime per-context method ran.
+       */
+      public bool $contextualized = FALSE;
+
+      public function active(): bool {
+        return TRUE;
+      }
+
+      public function type(): ?string {
+        return NULL;
+      }
+
+      public function contextualizeNotDrupalContext(NotDrupalContext $context): void {
+        $this->contextualized = TRUE;
+      }
+
+    };
+
+    // A context with no capability interface is dispatched by name at runtime.
+    $platform->contextualize(new NotDrupalContext());
+
+    $this->assertTrue($platform->contextualized);
+  }
+
+  public function testContextualizeWithoutMatchingMethodIsNoop(): void {
+    $platform = new class() extends AbstractPlatform {
 
       public function active(): bool {
         return TRUE;
@@ -47,7 +104,7 @@ final class AbstractPlatformTest extends EnvironmentDetectorTestCase {
 
     $platform->contextualize($context);
 
-    // The abstract contextualize is a no-op and leaves the context untouched.
+    // No capability interface and no runtime method, so nothing is applied.
     $this->assertSame([], $settings);
     $this->assertSame([], $config);
   }

--- a/tests/Platforms/AcquiaTest.php
+++ b/tests/Platforms/AcquiaTest.php
@@ -78,7 +78,7 @@ final class AcquiaTest extends PlatformTestCase {
   }
 
   public function testContextualizeNonDrupalIsNoop(): void {
-    // A non-Drupal context hits the type guard and returns without touching it.
+    // A non-Drupal context maps to no per-context method, so nothing happens.
     (new Acquia())->contextualize(new NotDrupalContext());
 
     $this->expectNotToPerformAssertions();

--- a/tests/Platforms/LagoonTest.php
+++ b/tests/Platforms/LagoonTest.php
@@ -108,7 +108,7 @@ final class LagoonTest extends PlatformTestCase {
   }
 
   public function testContextualizeNonDrupalIsNoop(): void {
-    // A non-Drupal context hits the type guard and returns without touching it.
+    // A non-Drupal context maps to no per-context method, so nothing happens.
     (new Lagoon())->contextualize(new NotDrupalContext());
 
     $this->expectNotToPerformAssertions();

--- a/tests/Platforms/SkprTest.php
+++ b/tests/Platforms/SkprTest.php
@@ -64,7 +64,7 @@ final class SkprTest extends PlatformTestCase {
   }
 
   public function testContextualizeNonDrupalIsNoop(): void {
-    // A non-Drupal context hits the type guard and returns without touching it.
+    // A non-Drupal context maps to no per-context method, so nothing happens.
     (new Skpr())->contextualize(new NotDrupalContext());
 
     $this->expectNotToPerformAssertions();

--- a/tests/Stacks/AbstractStackTest.php
+++ b/tests/Stacks/AbstractStackTest.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace DrevOps\EnvironmentDetector\Tests\Stacks;
 
 use DrevOps\EnvironmentDetector\Contexts\Drupal;
+use DrevOps\EnvironmentDetector\Contexts\DrupalContextualizerInterface;
 use DrevOps\EnvironmentDetector\Stacks\AbstractStack;
 use DrevOps\EnvironmentDetector\Tests\EnvironmentDetectorTestCase;
+use DrevOps\EnvironmentDetector\Tests\Fixtures\NotDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(AbstractStack::class)]
 final class AbstractStackTest extends EnvironmentDetectorTestCase {
 
   public function testIdDefaultsToConst(): void {
-    $stack = new class extends AbstractStack {
+    $stack = new class() extends AbstractStack {
 
       public function active(): bool {
         return FALSE;
@@ -24,8 +26,55 @@ final class AbstractStackTest extends EnvironmentDetectorTestCase {
     $this->assertSame('undefined', $stack->id());
   }
 
-  public function testContextualizeIsNoop(): void {
-    $stack = new class extends AbstractStack {
+  public function testContextualizeViaCapabilityInterface(): void {
+    $stack = new class() extends AbstractStack implements DrupalContextualizerInterface {
+
+      public function active(): bool {
+        return TRUE;
+      }
+
+      public function contextualizeDrupal(Drupal $context): void {
+        $context->settings['applied'] = 'drupal';
+      }
+
+    };
+
+    $settings = [];
+    $config = [];
+    $context = new Drupal($settings, $config);
+
+    $stack->contextualize($context);
+
+    // The typed capability interface is resolved and called directly.
+    $this->assertSame(['applied' => 'drupal'], $settings);
+  }
+
+  public function testContextualizeViaRuntimeReflection(): void {
+    $stack = new class() extends AbstractStack {
+
+      /**
+       * Records whether the runtime per-context method ran.
+       */
+      public bool $contextualized = FALSE;
+
+      public function active(): bool {
+        return TRUE;
+      }
+
+      public function contextualizeNotDrupalContext(NotDrupalContext $context): void {
+        $this->contextualized = TRUE;
+      }
+
+    };
+
+    // A context with no capability interface is dispatched by name at runtime.
+    $stack->contextualize(new NotDrupalContext());
+
+    $this->assertTrue($stack->contextualized);
+  }
+
+  public function testContextualizeWithoutMatchingMethodIsNoop(): void {
+    $stack = new class() extends AbstractStack {
 
       public function active(): bool {
         return TRUE;
@@ -39,7 +88,7 @@ final class AbstractStackTest extends EnvironmentDetectorTestCase {
 
     $stack->contextualize($context);
 
-    // The abstract contextualize is a no-op and leaves the context untouched.
+    // No capability interface and no runtime method, so nothing is applied.
     $this->assertSame([], $settings);
     $this->assertSame([], $config);
   }

--- a/tests/Stacks/ContainerTest.php
+++ b/tests/Stacks/ContainerTest.php
@@ -57,7 +57,7 @@ final class ContainerTest extends StackTestCase {
   }
 
   public function testContextualizeNonDrupalIsNoop(): void {
-    // A non-Drupal context hits the type guard and returns without touching it.
+    // A non-Drupal context maps to no per-context method, so nothing happens.
     (new Container())->contextualize(new NotDrupalContext());
 
     $this->expectNotToPerformAssertions();


### PR DESCRIPTION
Closes #92

## Summary

Added a `DrupalContextualizerInterface` that platforms and stacks implement to apply Drupal settings through a typed `contextualizeDrupal(Drupal $context)` method rather than a `contextualize(ContextInterface $context)` override with an `instanceof Drupal` guard. `AbstractPlatform::contextualize()` and `AbstractStack::contextualize()` now resolve this interface first (an `instanceof` check for speed), then fall back to a runtime reflection-based lookup that calls `contextualize<ContextName>()` if it exists - enabling custom rings that handle contexts defined outside the library. All four built-in rings (`Lagoon`, `Acquia`, `Skpr`, `Container`) were converted from the guard pattern to the interface. `Environment::applyActiveContext()` is unchanged. README examples were updated to show the typed path as the primary pattern, with the runtime override documented as the alternative.

## Changes

- **`src/Contexts/DrupalContextualizerInterface.php`** - New capability interface declaring `contextualizeDrupal(Drupal $context): void`.
- **`src/Platforms/AbstractPlatform.php`** / **`src/Stacks/AbstractStack.php`** - `contextualize()` now resolves `DrupalContextualizerInterface` first; falls back to `ReflectionClass::getShortName()`-derived method name for runtime contexts; is a no-op when neither path matches. Removed the three `phpcs:disable` suppressions that were masking a lint false-positive on the old empty body.
- **`src/Platforms/Acquia.php`**, **`Lagoon.php`**, **`Skpr.php`** / **`src/Stacks/Container.php`** - Each now `implements DrupalContextualizerInterface` and exposes a `contextualizeDrupal()` method instead of a `contextualize()` override with a type guard.
- **`tests/Platforms/AbstractPlatformTest.php`** / **`tests/Stacks/AbstractStackTest.php`** - Replaced the single `testContextualizeIsNoop` test with three targeted cases: typed capability interface dispatch, runtime reflection dispatch, and no-match no-op. Uses the existing `NotDrupalContext` fixture for the reflection case.
- **`README.md`** - Updated custom platform/stack code examples to show `DrupalContextualizerInterface` as the primary pattern, with an inline note pointing to `contextualize()` override for runtime contexts. Added a prose paragraph explaining the two-path dispatch model.

## Before / After

```
BEFORE
──────────────────────────────────────────────────────────────────
AbstractPlatform::contextualize(ContextInterface $context)
  └─ (no-op; override in subclass)

Acquia::contextualize(ContextInterface $context)          ← override
  ├─ if (!$context instanceof Drupal) { return; }        ← guard
  └─ // apply settings …

AbstractStack::contextualize(ContextInterface $context)
  └─ (no-op; override in subclass)

Container::contextualize(ContextInterface $context)       ← override
  ├─ if (!$context instanceof Drupal) { return; }        ← guard
  └─ // apply settings …

Custom ring extending AbstractPlatform:
  └─ must override contextualize() and add its own guard

──────────────────────────────────────────────────────────────────

AFTER
──────────────────────────────────────────────────────────────────
DrupalContextualizerInterface
  └─ contextualizeDrupal(Drupal $context): void           ← typed contract

AbstractPlatform::contextualize(ContextInterface $context)
  ├─ $this instanceof DrupalContextualizerInterface
  │    && $context instanceof Drupal
  │      → $this->contextualizeDrupal($context)          ← typed path (fast)
  ├─ else: reflect context short name
  │      → $this->contextualize<Name>($context)          ← runtime path
  └─ else: no-op

Acquia implements DrupalContextualizerInterface:
  └─ contextualizeDrupal(Drupal $context) { /* settings */ }

Container implements DrupalContextualizerInterface:
  └─ contextualizeDrupal(Drupal $context) { /* settings */ }

(same pattern for AbstractStack / Container / Lagoon / Skpr)

Custom ring - typed (built-in context):
  class CustomPlatform extends AbstractPlatform
      implements DrupalContextualizerInterface {
    public function contextualizeDrupal(Drupal $ctx): void { … }
  }

Custom ring - runtime (third-party context):
  class CustomPlatform extends AbstractPlatform {
    public function contextualizeMyContext(MyContext $ctx): void { … }
  }
──────────────────────────────────────────────────────────────────
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Drupal-aware contextualization for supported platforms and stacks, improving how environment settings are applied in Drupal setups.
  * Expanded support for both typed Drupal contexts and fallback context-specific methods.

* **Documentation**
  * Updated the integration guide to show the newer extension pattern for custom platforms and stacks.
  * Clarified how built-in and runtime-defined contexts are handled.

* **Tests**
  * Expanded test coverage for typed contextualization, runtime method dispatch, and no-op behavior when no matching context handler exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->