### PR TITLE
[#93] Added a 'SERVICE_HOSTS' env variable to extend the container trusted-host allowlist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Beyond the platform and stack detection signals the hosting or CI provider sets 
 | `DRUPAL_TMP_PATH_IS_SHARED` | When truthy, points `file_temp_path` at the shared GFS mount (`/mnt/gfs/<group>.<env>/tmp`). | Acquia | `file_temp_path` stays `/tmp`. |
 | `DRUPAL_ACQUIA_SETTINGS_FILE` | Overrides the path to the Acquia-provided `*-settings.inc` file that is included. | Acquia | `/var/www/site-php/<group>/<group>-settings.inc`. |
 | `LOCALDEV_URL` | The site's local development URL, added as a Drupal `trusted_host_patterns` entry (the scheme is stripped). | Container stack | Only the built-in service-host allowlist (`web`, `app`, `webserver`, `nginx`, `apache`, `apache2`) is added. |
-| `SERVICE_HOSTS` | Comma-separated internal service hostnames appended to the built-in container allowlist, each added as a Drupal `trusted_host_patterns` entry (entries are trimmed, blanks dropped, and regex metacharacters escaped). | Container stack | Only the built-in service-host allowlist (`web`, `app`, `webserver`, `nginx`, `apache`, `apache2`) is added. |
+| `SERVICE_HOSTS` | Comma-separated internal service hostnames merged with the built-in container allowlist into a single Drupal `trusted_host_patterns` alternation regex (entries are trimmed, blanks dropped, and regex metacharacters escaped). | Container stack | Only the built-in service-host allowlist (`web`, `app`, `webserver`, `nginx`, `apache`, `apache2`) is added. |
 
 The `DRUPAL_*` variables take effect only when the [Drupal](#contexts) context is active.
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Beyond the platform and stack detection signals the hosting or CI provider sets 
 | `DRUPAL_TMP_PATH_IS_SHARED` | When truthy, points `file_temp_path` at the shared GFS mount (`/mnt/gfs/<group>.<env>/tmp`). | Acquia | `file_temp_path` stays `/tmp`. |
 | `DRUPAL_ACQUIA_SETTINGS_FILE` | Overrides the path to the Acquia-provided `*-settings.inc` file that is included. | Acquia | `/var/www/site-php/<group>/<group>-settings.inc`. |
 | `LOCALDEV_URL` | The site's local development URL, added as a Drupal `trusted_host_patterns` entry (the scheme is stripped). | Container stack | Only the built-in service-host allowlist (`web`, `app`, `webserver`, `nginx`, `apache`, `apache2`) is added. |
+| `SERVICE_HOSTS` | Comma-separated internal service hostnames appended to the built-in container allowlist, each added as a Drupal `trusted_host_patterns` entry (entries are trimmed, blanks dropped, and regex metacharacters escaped). | Container stack | Only the built-in service-host allowlist (`web`, `app`, `webserver`, `nginx`, `apache`, `apache2`) is added. |
 
 The `DRUPAL_*` variables take effect only when the [Drupal](#contexts) context is active.
 

--- a/src/Stacks/Container.php
+++ b/src/Stacks/Container.php
@@ -71,8 +71,27 @@ class Container extends AbstractStack implements DrupalContextualizerInterface {
   public function contextualizeDrupal(Drupal $context): void {
     $settings = &$context->settings;
 
-    // Internal service hostnames, reachable container-to-container.
-    $settings['trusted_host_patterns'][] = '^(' . implode('|', static::SERVICE_HOSTS) . ')$';
+    // Internal service hostnames, reachable container-to-container. The
+    // SERVICE_HOSTS env var contributes extra comma-separated hosts on top of
+    // the built-in allowlist. Every host is escaped before joining the
+    // alternation: the pattern feeds the security-sensitive
+    // trusted_host_patterns, so a host carrying a regex metacharacter must not
+    // be able to widen the match.
+    $hosts = static::SERVICE_HOSTS;
+
+    $extra = getenv('SERVICE_HOSTS');
+    if (is_string($extra)) {
+      foreach (explode(',', $extra) as $host) {
+        $host = trim($host);
+
+        if ($host !== '') {
+          $hosts[] = $host;
+        }
+      }
+    }
+
+    $hosts = array_map(static fn(string $host): string => preg_quote($host, '#'), $hosts);
+    $settings['trusted_host_patterns'][] = '^(' . implode('|', array_unique($hosts)) . ')$';
 
     // The site's local development URL, reduced to its host: a port, path, or
     // credentials would never match Drupal's host-only trusted-host check.

--- a/tests/Stacks/ContainerTest.php
+++ b/tests/Stacks/ContainerTest.php
@@ -116,6 +116,65 @@ final class ContainerTest extends StackTestCase {
         ],
       ],
     ];
+    // The SERVICE_HOSTS env var appends a custom host to the allowlist.
+    yield 'single custom service host' => [
+      fn(): null => self::envSet('SERVICE_HOSTS', 'php'),
+      [
+        'trusted_host_patterns' => [
+          '^(web|app|webserver|nginx|apache|apache2|php)$',
+        ],
+      ],
+    ];
+    // Multiple comma-separated hosts are all appended, in order.
+    yield 'multiple custom service hosts' => [
+      fn(): null => self::envSet('SERVICE_HOSTS', 'php,cli'),
+      [
+        'trusted_host_patterns' => [
+          '^(web|app|webserver|nginx|apache|apache2|php|cli)$',
+        ],
+      ],
+    ];
+    // Surrounding whitespace is trimmed and blank entries are dropped.
+    yield 'whitespace and blank service hosts' => [
+      fn(): null => self::envSet('SERVICE_HOSTS', ' php , , cli ,'),
+      [
+        'trusted_host_patterns' => [
+          '^(web|app|webserver|nginx|apache|apache2|php|cli)$',
+        ],
+      ],
+    ];
+    // A regex metacharacter in a custom host is escaped, so the dot stays
+    // literal and cannot widen the trusted-host match.
+    yield 'custom service host is regex-escaped' => [
+      fn(): null => self::envSet('SERVICE_HOSTS', 'php.internal'),
+      [
+        'trusted_host_patterns' => [
+          '^(web|app|webserver|nginx|apache|apache2|php\.internal)$',
+        ],
+      ],
+    ];
+    // A custom host duplicating a built-in is emitted only once.
+    yield 'duplicate built-in service host' => [
+      fn(): null => self::envSet('SERVICE_HOSTS', 'web,php'),
+      [
+        'trusted_host_patterns' => [
+          '^(web|app|webserver|nginx|apache|apache2|php)$',
+        ],
+      ],
+    ];
+    // Extended allowlist and the LOCALDEV_URL host coexist, allowlist first.
+    yield 'custom service host with localdev url' => [
+      function (): void {
+          self::envSet('SERVICE_HOSTS', 'php');
+          self::envSet('LOCALDEV_URL', 'https://mysite.local');
+      },
+      [
+        'trusted_host_patterns' => [
+          '^(web|app|webserver|nginx|apache|apache2|php)$',
+          '^mysite\.local$',
+        ],
+      ],
+    ];
   }
 
 }


### PR DESCRIPTION
Closes #93

## Summary

The `Container` stack's `contextualizeDrupal()` method previously used a fixed six-host allowlist (`web`, `app`, `webserver`, `nginx`, `apache`, `apache2`) as the `trusted_host_patterns` alternation regex. Projects running additional internal services (e.g. a `php` or `cli` container) had no way to extend that list without forking the library. This change reads an optional `SERVICE_HOSTS` environment variable, parses its comma-separated entries (trimming whitespace, dropping blanks, escaping regex metacharacters, and de-duplicating against the built-in list), and merges them into the single combined pattern before it is emitted into Drupal settings.

## Changes

**`src/Stacks/Container.php`**
- `contextualizeDrupal()` now reads `SERVICE_HOSTS` via `getenv()` and, when present, appends each trimmed non-blank entry to the host list.
- All hosts (built-in and custom) are passed through `preg_quote()` with `#` as the delimiter before joining the alternation, preventing any metacharacter in a custom hostname from widening the trusted-host match.
- `array_unique()` drops duplicates so a custom entry that repeats a built-in appears only once in the compiled pattern.
- The final `trusted_host_patterns` entry is still a single `^(alt1|alt2|...)$` pattern, unchanged in structure.

**`tests/Stacks/ContainerTest.php`**
- Six new data-provider cases cover: single host, multiple hosts, whitespace/blank handling, regex-escaping of a dotted hostname, de-duplication of a built-in host, and coexistence with `LOCALDEV_URL`.

**`README.md`**
- Added a `SERVICE_HOSTS` row to the environment-variables reference table, describing the merge behaviour and the default when the variable is absent.

## Before / After

```
Before
──────
Container::contextualizeDrupal()
  trusted_host_patterns[] = '^(web|app|webserver|nginx|apache|apache2)$'
  [no way to add more hosts without forking]

After
─────
Container::contextualizeDrupal()
  hosts = [web, app, webserver, nginx, apache, apache2]
  + SERVICE_HOSTS=php,cli  →  hosts += [php, cli]   (trimmed, blanks dropped)
  + preg_quote each host   →  metacharacters escaped
  + array_unique           →  duplicates removed
  trusted_host_patterns[] = '^(web|app|webserver|nginx|apache|apache2|php|cli)$'

  LOCALDEV_URL still adds its own separate entry, unchanged:
  trusted_host_patterns[] = '^mysite\.local$'
```
